### PR TITLE
Configure docker-compose with nginx and wordpress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # docker-wordpress
+
+Este projeto define um ambiente Docker com quatro serviços principais:
+
+- **nginx**: atua como proxy reverso expondo o WordPress em `/wordpress`.
+- **mysql 5.7**: banco de dados utilizado pelo WordPress.
+- **wordpress**: aplicação web WordPress.
+- **phpmyadmin**: interface para administração do banco de dados.
+
+## Como executar
+
+1. Execute `docker compose up -d` para iniciar todos os serviços.
+2. Acesse o WordPress em [http://localhost/wordpress](http://localhost/wordpress).
+3. Para acessar o phpMyAdmin utilize [http://localhost:8080](http://localhost:8080).
+
+O WordPress não ficará disponível diretamente em `http://localhost`, apenas por meio do nginx na rota `/wordpress`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.9'
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: wordpress
+    volumes:
+      - db_data:/var/lib/mysql
+
+  wordpress:
+    image: wordpress:latest
+    depends_on:
+      - db
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: root
+      WORDPRESS_DB_PASSWORD: example
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_CONFIG_EXTRA: |
+        define('WP_HOME','http://localhost/wordpress');
+        define('WP_SITEURL','http://localhost/wordpress');
+    volumes:
+      - wp_data:/var/www/html
+    restart: always
+
+  nginx:
+    image: nginx:alpine
+    depends_on:
+      - wordpress
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "80:80"
+    restart: always
+
+  phpmyadmin:
+    image: phpmyadmin:latest
+    depends_on:
+      - db
+    environment:
+      PMA_HOST: db
+    ports:
+      - "8080:80"
+    restart: always
+
+volumes:
+  db_data:
+  wp_data:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+
+    location /wordpress/ {
+        proxy_pass http://wordpress:80/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location / {
+        return 404;
+    }
+}


### PR DESCRIPTION
## Summary
- set up a Docker Compose stack with nginx, WordPress, MySQL 5.7 and phpMyAdmin
- expose WordPress only through nginx under `/wordpress`
- document how to run the stack

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68645c0e79e48328ba8b34dc3d6fd6ef